### PR TITLE
Fix lerna version in README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prerequisites: [Node (v16 LTS)](https://nodejs.org/en/download/) plus [Yarn](htt
 ```sh
 git clone https://github.com/gitcoinco/passport.git
 cd passport
-npm install --global lerna
+npm install --global lerna@^4.0.0
 lerna init
 lerna bootstrap
 ```


### PR DESCRIPTION
I was not able to execute
```bash
lerna init
lerna bootstrap
```
with the default version of `lerna` that is installed with `npm install lerna` (v8.0.0), so I updated the command in the README to include the version of lerna specified in `package.json` 
