### PR TITLE
chore(platforms): changing slotId in civic pass api response from a number to a hex string

### DIFF
--- a/platforms/src/Civic/Providers/types.ts
+++ b/platforms/src/Civic/Providers/types.ts
@@ -32,7 +32,7 @@ type CivicPassState = "ACTIVE" | "FROZEN" | "REVOKED";
 
 export type CivicPassLookupPass = {
   type: {
-    slotId: number;
+    slotId: string; // hex string
     address: string;
     name?: string;
   };

--- a/platforms/src/Civic/__tests__/civic.test.ts
+++ b/platforms/src/Civic/__tests__/civic.test.ts
@@ -24,7 +24,7 @@ const dummyPass: CivicPassLookupPass = {
   expiry: now + expirySeconds,
   state: "ACTIVE",
   type: {
-    slotId: 0,
+    slotId: "0x00",
     address: userAddress,
   },
   identifier: "0x456",


### PR DESCRIPTION
Civic is changing its process for the creation of new pass types - specifically we are no longer using incremental [slotIds](https://whitepaper.sftlabs.io/SFT%20Whitepaper.pdf), but instead using 32-byte keys, to improve interoperability between  different chains.

This PR makes the minor changes to the passport integration to support this. The change is forwards-compatible, has no effect on user-experience, and can be merged at any time without first consulting Civic.