### PR TITLE
fix: call compose retry once onboarding is complete

### DIFF
--- a/app/__test-fixtures__/contextTestHelpers.tsx
+++ b/app/__test-fixtures__/contextTestHelpers.tsx
@@ -98,6 +98,7 @@ export const makeTestCeramicContext = (initialState?: Partial<CeramicContextStat
     handlePatchStamps: jest.fn(),
     handleCreatePassport: jest.fn(),
     handleDeleteStamps: jest.fn(),
+    handleComposeRetry: jest.fn(),
     expiredProviders: [],
     expiredPlatforms: {},
     passportHasCacaoError: false,

--- a/app/__tests__/context/ceramicContext.test.tsx
+++ b/app/__tests__/context/ceramicContext.test.tsx
@@ -6,6 +6,7 @@ import {
   CeramicContextState,
   handleComposeRetry,
   cleanPassport,
+  getStampsToRetry,
 } from "../../context/ceramicContext";
 import { ComposeDatabase, PassportDatabase } from "@gitcoin/passport-database-client";
 import { useEffect, useContext } from "react";
@@ -1169,12 +1170,8 @@ describe("CeramicContextProvider syncs stamp state with ceramic", () => {
 
     await waitFor(() => fireEvent.click(screen.getByText("handlePatchStamps")));
     await waitFor(() => expect(patchStampsMock).toHaveBeenCalledWith(stampPatches));
-    await waitFor(() =>
-      expect(
-        screen.getByText(
-          "Your update was not logged to Ceramic. Please refresh the page to reset your Ceramic session."
-        )
-      ).toBeInTheDocument()
+    await screen.findByText(
+      "Your update was not logged to Ceramic. Please refresh the page to reset your Ceramic session."
     );
   });
 });
@@ -1238,11 +1235,11 @@ describe("cleanPassport function", () => {
 
 describe("handleComposeRetry function", () => {
   it("should detect a difference between the stamps in the database and the stamps in ceramic", async () => {
-    const result = handleComposeRetry(composeStamps, databasePassport);
-    expect(result).toBeInstanceOf(Promise<SecondaryStorageBulkPatchResponse>);
+    const result = getStampsToRetry(composeStamps, databasePassport.stamps);
+    expect(result).toHaveLength(2);
   });
   it("should not return anything if the stamps in the database and the stamps in ceramic are the same", async () => {
-    const result = handleComposeRetry(databasePassport.stamps, databasePassport);
-    expect(result).toBeInstanceOf(Promise<undefined>);
+    const result = getStampsToRetry(databasePassport.stamps, databasePassport.stamps);
+    expect(result).toHaveLength(0);
   });
 });

--- a/app/context/ceramicContext.tsx
+++ b/app/context/ceramicContext.tsx
@@ -39,6 +39,7 @@ export interface CeramicContextState {
   handlePatchStamps: (stamps: StampPatch[]) => Promise<void>;
   handleDeleteStamps: (providerIds: PROVIDER_ID[]) => Promise<void>;
   cancelCeramicConnection: () => void;
+  handleComposeRetry: () => Promise<SecondaryStorageBulkPatchResponse | void>;
   userDid: string | undefined;
   expiredProviders: PROVIDER_ID[];
   expiredPlatforms: Partial<Record<PLATFORM_ID, PlatformProps>>;
@@ -91,35 +92,6 @@ const startingAllProvidersState: AllProvidersState = Object.values(stampPlatform
   {}
 );
 
-export const handleComposeRetry = async (
-  composeStamps: Stamp[],
-  passDbPassport: Passport,
-  ceramicClient?: ComposeDatabase
-): Promise<SecondaryStorageBulkPatchResponse | void> => {
-  if (ceramicClient) {
-    try {
-      // using stamps as the source of truth, filter stamps for where the issuanceDate does not match the composeStamp if there is a composeStamp with the same provider
-      const stampsToRetry = passDbPassport.stamps.filter((stamp: Stamp) => {
-        const existingStamp = composeStamps.find((composeStamp: Stamp) => stamp.provider === composeStamp.provider);
-        if (!existingStamp || stamp.credential.issuanceDate !== existingStamp.credential.issuanceDate) {
-          return true;
-        }
-      });
-      // then add the stamps to ComposeDB
-      if (stampsToRetry.length > 0) {
-        // perform an update using the stamps that need to be retried
-        const composeDBPatchResponse = await ceramicClient.patchStamps(stampsToRetry);
-        return composeDBPatchResponse;
-      } else {
-        console.log("No stamps to retry");
-      }
-    } catch (e) {
-      console.log("error adding ceramic stamps", e);
-      datadogLogs.logger.error("Error adding ceramic stamps", { stamps: composeStamps, error: e });
-    }
-  }
-};
-
 const startingState: CeramicContextState = {
   passport: undefined,
   isLoadingPassport: IsLoadingPassportState.Loading,
@@ -129,6 +101,7 @@ const startingState: CeramicContextState = {
   handleAddStamps: async () => {},
   handlePatchStamps: async () => {},
   handleDeleteStamps: async () => {},
+  handleComposeRetry: async () => {},
   passportHasCacaoError: false,
   cancelCeramicConnection: () => {},
   userDid: undefined,
@@ -299,20 +272,32 @@ export const CeramicContextProvider = ({ children }: { children: any }) => {
     }
   }, [ceramicClient]);
 
-  useEffect(() => {
+  const handleComposeRetry = async (): Promise<SecondaryStorageBulkPatchResponse | void> => {
     if (initialPassport && ceramicClient && initialCeramicStamps) {
-      handleComposeRetry(initialCeramicStamps, initialPassport, ceramicClient)
-        .then((response) => {
-          if (response) {
-            console.log("retry response", response);
+      try {
+        // using stamps as the source of truth, filter stamps for where the issuanceDate does not match the composeStamp if there is a composeStamp with the same provider
+        const stampsToRetry = initialPassport.stamps.filter((stamp: Stamp) => {
+          const existingStamp = initialCeramicStamps.find(
+            (composeStamp: Stamp) => stamp.provider === composeStamp.provider
+          );
+          if (!existingStamp || stamp.credential.issuanceDate !== existingStamp.credential.issuanceDate) {
+            return true;
           }
-        })
-        .catch((e) => {
-          console.log("error retrying stamps", e);
-          datadogLogs.logger.error("Error retrying stamps", { error: e });
         });
+        // then add the stamps to ComposeDB
+        if (stampsToRetry.length > 0) {
+          // perform an update using the stamps that need to be retried
+          const composeDBPatchResponse = await ceramicClient.patchStamps(stampsToRetry);
+          return composeDBPatchResponse;
+        } else {
+          console.log("No stamps to retry");
+        }
+      } catch (e) {
+        console.log("error adding ceramic stamps", e);
+        datadogLogs.logger.error("Error adding ceramic stamps", { stamps: initialCeramicStamps, error: e });
+      }
     }
-  }, [initialCeramicStamps, initialPassport, ceramicClient]);
+  };
 
   const checkAndAlertInvalidCeramicSession = useCallback(() => {
     if (!checkSessionIsValid()) {
@@ -695,6 +680,7 @@ export const CeramicContextProvider = ({ children }: { children: any }) => {
     handlePatchStamps,
     handleDeleteStamps,
     cancelCeramicConnection,
+    handleComposeRetry,
     userDid,
     expiredProviders,
     expiredPlatforms,

--- a/app/hooks/useOneClickVerification.tsx
+++ b/app/hooks/useOneClickVerification.tsx
@@ -1,5 +1,5 @@
 import { PROVIDER_ID, StampPatch, ValidResponseBody } from "@gitcoin/passport-types";
-import { useContext, useMemo } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import { fetchPossibleEVMStamps } from "../signer/utils";
 import { IAM_SIGNATURE_TYPE, iamUrl } from "../config/stamp_config";
 import { fetchVerifiableCredential } from "@gitcoin/passport-identity";
@@ -14,7 +14,7 @@ import { useMessage } from "./useMessage";
 export const useOneClickVerification = () => {
   const [verificationState, setUserVerificationState] = useAtom(mutableUserVerificationAtom);
 
-  const { passport, allPlatforms, handlePatchStamps } = useContext(CeramicContext);
+  const { passport, allPlatforms, handlePatchStamps, handleComposeRetry } = useContext(CeramicContext);
   const { success } = useMessage();
 
   const initiateVerification = async function (did: DID, address: string) {
@@ -98,6 +98,12 @@ export const useOneClickVerification = () => {
   const verificationComplete = useMemo(() => {
     return verificationState.error || verificationState.success;
   }, [verificationState.error, verificationState.success]);
+
+  useEffect(() => {
+    if (verificationComplete) {
+      handleComposeRetry();
+    }
+  }, [handleComposeRetry, verificationComplete]);
 
   return { initiateVerification, verificationState, verificationComplete };
 };


### PR DESCRIPTION
fixes: {\"error\":\"Commit to stream  rejected because it builds on stale state. Calling 'sync()' on the stream handle will synchronize the stream state in the client with that on the Ceramic node.  Rejected commit CID:...