### PR TITLE
feat: update app metadata branding from 'Passport XYZ' to 'Human Passport'

### DIFF
--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -102,7 +102,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (customization.key !== DEFAULT_CUSTOMIZATION_KEY) {
-      document.title = `Passport XYZ | ${
+      document.title = `Human Passport | ${
         customization.key.charAt(0).toUpperCase() + customization.key.slice(1)
       } Dashboard`;
       TagManager.dataLayer({
@@ -111,7 +111,7 @@ export default function Dashboard() {
         },
       });
     } else {
-      document.title = `Passport XYZ | Dashboard`;
+      document.title = `Human Passport | Dashboard`;
       TagManager.dataLayer({
         dataLayer: {
           event: "default-dashboard-view",

--- a/app/pages/Maintenance.tsx
+++ b/app/pages/Maintenance.tsx
@@ -28,7 +28,7 @@ export default function Maintenance() {
             className="col-span-2 w-full max-w-md lg:col-start-1 lg:row-span-6 lg:mr-8 lg:max-w-2xl"
           />
           <div className="col-span-2 max-w-md text-lg lg:max-w-sm">
-            Passport XYZ is currently down for scheduled maintenance. Please check back again as we will be back up
+            Human Passport is currently down for scheduled maintenance. Please check back again as we will be back up
             shortly. For more information, check{" "}
             <Hyperlink href="https://twitter.com/gitcoinpassport">@GitcoinPassport</Hyperlink> for updates.
           </div>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -93,7 +93,7 @@ function App({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <link rel="shortcut icon" href="/favicon.png" />
-        <title>Passport XYZ</title>
+        <title>Human Passport</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
       </Head>
       <Web3Context>

--- a/platforms/src/Idena/App-Bindings.ts
+++ b/platforms/src/Idena/App-Bindings.ts
@@ -13,7 +13,7 @@ export class IdenaPlatform extends Platform {
 
   banner = {
     heading:
-      "Connect Idena to Passport XYZ for enhanced identity verification, confirming your human presence without sharing personal details. This guide simplifies the connection process.",
+      "Connect Idena to Human Passport for enhanced identity verification, confirming your human presence without sharing personal details. This guide simplifies the connection process.",
     cta: {
       label: "Help Guide",
       url: "https://support.passport.xyz/passport-knowledge-base/stamps/how-do-i-add-passport-stamps/idena-stamp",


### PR DESCRIPTION
## Changes Made

This PR updates the app metadata branding to use 'Human Passport' instead of 'Passport XYZ' across the application.

### 🔄 Branding Updates

**Page Titles:**
- **Default Title:** Updated from 'Passport XYZ' to 'Human Passport' in 
- **Dashboard Titles:** Updated both customization and default dashboard titles
  - Default: 'Passport XYZ | Dashboard' → 'Human Passport | Dashboard'
  - Custom: 'Passport XYZ | [Custom] Dashboard' → 'Human Passport | [Custom] Dashboard'

**User-Facing Content:**
- **Maintenance Page:** Updated maintenance message to reference 'Human Passport'
- **Platform Description:** Updated Idena connection description in platform bindings

### 📱 Impact

These changes affect:
- Browser tab titles across all pages
- Bookmark names when users bookmark pages
- Search engine results (when indexed)
- Social media sharing titles
- Platform descriptions in the stamp drawer

### 🔧 Technical Details

- Modified  - Default page title
- Modified  - Dynamic dashboard titles
- Modified  - Maintenance page message
- Modified  - Platform description

### ✅ Testing

- All changes are user-facing metadata updates
- No functional changes to application behavior
- Browser tab titles will now display 'Human Passport' consistently