### PR TITLE
Add hover effects to unverified stamp cards

### DIFF
--- a/app/components/PlatformCard.tsx
+++ b/app/components/PlatformCard.tsx
@@ -96,7 +96,7 @@ const DefaultStamp = ({ idx, platform, className, onClick, variant, isHumanTech,
   return (
     <div data-testid="platform-card" onClick={onClick} className={className} key={`${platform.name}${idx}`}>
       <div
-        className={`group relative flex h-full cursor-pointer flex-col rounded-2xl p-0 transition-all ease-out ${variantClasses[variant || "default"]}`}
+        className={`group relative flex h-full cursor-pointer flex-col rounded-2xl p-0 transition-all duration-200 hover:scale-[1.01] hover:shadow-md ${variantClasses[variant || "default"]}`}
       >
         <div className="m-4 flex h-full flex-col justify-between">
           <div className="flex w-full items-center justify-between">


### PR DESCRIPTION
## Summary
Adds consistent hover effects to unverified stamp cards in the main dashboard to match the existing credential cards in the stamp drawer.

## Changes
- Apply same hover effects from  to  component
- Add  for subtle scale animation 
- Add  for shadow effect on hover
- Update transition from  to  for consistency

## Requirements Met
✅ Only unverified stamp cards are affected  
✅ Uses identical effects as credential cards  
✅ Verified and expired stamp cards remain unchanged  

## Testing
- ✅ All tests pass
- ✅ Linting passes  
- ✅ Hover effects confirmed working locally

The hover effects provide consistent visual feedback across the UI, improving user experience when interacting with stamp cards.