### PR TITLE
fix: remove clientid from sdk init - use default one from zkemail

### DIFF
--- a/platforms/src/ZKEmail/App-Bindings.tsx
+++ b/platforms/src/ZKEmail/App-Bindings.tsx
@@ -115,7 +115,7 @@ export class ZKEmailPlatform extends Platform {
   async handleLoginAndProve(): Promise<void> {
     const { initZkEmailSdk, Gmail, LoginWithGoogle } = await this.getZkEmailSdk();
 
-    const loginWithGoogle = new LoginWithGoogle({ clientId: this.clientId });
+    const loginWithGoogle = new LoginWithGoogle();
 
     const gmail = new Gmail(loginWithGoogle);
     if (!loginWithGoogle.accessToken) {


### PR DESCRIPTION
- Uses our own google client id for oauth since we need to explicitly ask specific permissions for the user to approve