### PR TITLE
fix(app): improve text contrast in dark theme for embed campaign widget

### DIFF
--- a/app/components/EmbedCampaign.tsx
+++ b/app/components/EmbedCampaign.tsx
@@ -316,7 +316,7 @@ export const EmbedCampaign = () => {
               collapseMode={{ None: "off", Shift: "shift", Overlay: "overlay" }[collapseType] as CollapseMode}
               {...passportEmbedParams}
             />
-            <div className={selectedTheme === "Dark" ? "text-color-1" : "text-color-4"}>Text below the widget.</div>
+            <div className={selectedTheme === "Dark" ? "text-color-9" : "text-color-4"}>Text below the widget.</div>
           </div>
           <img
             className="w-full h-auto col-start-1 row-start-4 hidden lg:block"


### PR DESCRIPTION
## Summary
- Changed text-color-1 (white) to text-color-9 (gray) for better readability in dark theme
- Maintains text-color-4 (black) for light theme
- Improves text contrast for "Text below the widget." in embed campaign

## Test plan
- [ ] Test embed campaign page in dark theme
- [ ] Test embed campaign page in light theme
- [ ] Verify text readability and contrast

🤖 Generated with [Claude Code](https://claude.ai/code)