### PR TITLE
fix(GtcStaking): point Identity Staking links at stake.passport.xyz

### DIFF
--- a/platforms/src/GtcStaking/App-Bindings.tsx
+++ b/platforms/src/GtcStaking/App-Bindings.tsx
@@ -38,7 +38,7 @@ export class GTCStakingPlatform extends Platform {
     ),
     cta: {
       label: "Identity Staking",
-      url: "https://www.staking.passport.gitcoin.co/",
+      url: "https://stake.passport.xyz/",
     },
   };
 }

--- a/platforms/src/GtcStaking/Providers-config.ts
+++ b/platforms/src/GtcStaking/Providers-config.ts
@@ -14,7 +14,7 @@ export const PlatformDetails: PlatformSpec = {
   name: "Identity Staking",
   description: "Stake GTC to boost trust in the ecosystem",
   connectMessage: "Verify amount",
-  website: "https://staking.passport.gitcoin.co/",
+  website: "https://stake.passport.xyz/",
   isEVM: true,
   timeToGet: "10-20 minutes",
   price: "5-125 GTC + gas fees",


### PR DESCRIPTION
## What

Two URLs in the GtcStaking platform, swapped to `https://stake.passport.xyz/`.

- `platforms/src/GtcStaking/App-Bindings.tsx:41` — the Identity Staking CTA button
- `platforms/src/GtcStaking/Providers-config.ts:17` — the platform `website` field

## Why

`staking.passport.gitcoin.co` and `www.staking.passport.gitcoin.co` stopped resolving on 18 August 2026. The `gitcoin.co` zone lost its NS delegation, and we do not control that zone. The decision was to leave the old route off rather than ask for it back.

Both names now return NXDOMAIN, so a user who clicks the Identity Staking card gets a browser DNS error rather than a page. Identity Staking is an active Stamp, currently weighted 12.506, so this is on a live path.

## Why this value

`stake.passport.xyz` is the live staking app and returns 200.

This platform already points there in two other places — the "Start Staking" CTA at `Providers-config.ts:23` and the guide step at line 46. These two URLs were simply missed in the earlier migration, so this brings the file back to one consistent host.

`staking.passport.xyz` also resolves, but it redirects to `stake.passport.xyz`. Pointing at the redirect target avoids an extra hop.

## Scope

Two string changes, no logic touched.

Related, and deliberately not in this PR: `app/.env-prod` still references several dead `gitcoin.co` hosts. Those are stale rather than live — the shipped bundle does not use them — so they belong in their own cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)