### PR TITLE
fix(infra): point REDIS_URL at the raw ElastiCache endpoint

### DIFF
--- a/infra/aws/stacks.ts
+++ b/infra/aws/stacks.ts
@@ -5,7 +5,11 @@ const coreInfraStack = new pulumi.StackReference(`organization/core-infra/${stac
 
 export const vpcId = coreInfraStack.getOutput("vpcId");
 export const vpcPrivateSubnets = coreInfraStack.getOutput("privateSubnetIds");
-export const redisConnectionUrl = pulumi.interpolate`${coreInfraStack.getOutput("staticRedisConnectionUrl")}`;
+// Use the raw ElastiCache node endpoint rather than the `staticRedisConnectionUrl`
+// DNS alias: that alias lives at core-redis.api.scorer.gitcoin.co, and the parent
+// gitcoin.co zone (Gitcoin-controlled) no longer delegates to api.scorer.gitcoin.co,
+// so the name NXDOMAINs everywhere including inside the VPC.
+export const redisConnectionUrl = pulumi.interpolate`${coreInfraStack.getOutput("redisConnectionUrl")}`;
 
 // Public ALB Data
 export const albDnsName = coreInfraStack.getOutput("coreAlbDns");


### PR DESCRIPTION
## What broke

At ~03:20 UTC on 2026-08-19, `core-redis.api.scorer.gitcoin.co` stopped resolving. The CNAME is still there — in the `api.scorer.gitcoin.co` public hosted zone (`Z10139513E2MYLFK9HBIU`), pointing at the right node. What's gone is the **NS delegation in the parent `gitcoin.co` zone**, which Gitcoin controls. Querying gitcoin.co's authoritative servers for anything under `scorer.gitcoin.co` returns the gitcoin.co SOA instead of a referral, so the zone is orphaned and the name NXDOMAINs everywhere, VPC resolver included. Nothing in our Pulumi state changed.

`REDIS_URL` for both `passport-xyz-iam` and `passport-embed` points at that name.

## Why embed crash-loops and iam doesn't

`passport-embed` has been cycling every ~3 minutes since. Each task lives 10.6 seconds:

```
03:27:16  server started at http://localhost:80
03:27:16  Redis connection error: getaddrinfo ENOTFOUND core-redis.api.scorer.gitcoin.co  (×21)
03:27:27  file:///app/identity/dist/esm/humanNetworkOprf.js:8
                  throw err;
          MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20).
```

ioredis exhausts its default `maxRetriesPerRequest: 20` (~11s of backoff — hence the 10.6s lifetimes), the queued command rejects, the rejection is unhandled, Node 22 turns that into an `uncaughtException`, and the process-wide handler at `identity/src/humanNetworkOprf.ts:7-12` re-throws it, which is fatal. The `redis.on("error")` handler in `embed/src/redis.ts:11` catches the connection events (those 21 log lines) but not this one. ECS then replaces the task and it repeats — no health-check failures involved, which is why the ALB never showed an unhealthy target.

`passport-xyz-iam` stays up because its only Redis use is `iam/src/utils/easFees.ts:41-48`, a lazy path wrapped in try/catch. It logs ~2 connection errors/sec instead.

## The fix

core-infra already exports `redisConnectionUrl` next to the DNS alias — the raw node endpoint, which is what `passport-scorer` already uses for its Celery broker. Switching to it requires no core-infra deploy.

Verified against production before opening this:

| Check | Result |
|---|---|
| Output exists in deployed core-infra prod state | `redis://core-redis-2b5d705.4czlqg.0001.usw2.cache.amazonaws.com:6379/0`, plaintext, not a secret |
| Endpoint resolves | → `10.0.154.139` |
| Same cluster the dead CNAME targets | byte-identical hostname; cluster `available` |
| Network path | redis SG `sg-075d8388fbd228bba` allows tcp/6379 from `10.0.0.0/16`; embed/iam are Fargate in `vpc-009fc720ebe029ac0` private subnets; VPC DNS support on |
| Auth/TLS | none — `AuthTokenEnabled=false`, `TransitEncryptionEnabled=false`; plain `redis://`, db `/0`, unchanged |
| Other consumers of the dead name | none — across all 6 prod stacks the only non-`StackReference` consumers are these two task definitions |
| Pulumi diff | no `infra/` commits since the last apply (2026-08-07), so preview should show only the two task-definition replacements |

Staging is broken identically and is fixed by the same line (`redis://core-redis-6ce6706.gmwx3w.0001.usw2.cache.amazonaws.com:6379/0`, resolves to `10.0.107.241`).

## Deploying this

Use **Build and Deploy API to Production**, not **Pulumi Only - Deploy Infra**. `infra.yml` passes the commit ref through to `DOCKER_IMAGE_TAG` (`infra/aws/embed.ts:25`, `iam.ts:28`), so running it on this commit would point both task definitions at an ECR tag that was never built, and unlike `deploy_generic.yml` it has no `verify_image_ecr` gate.

## Follow-ups, not in this PR

- Embed dying on any Redis interruption is latent fragility this PR only masks. `maxRetriesPerRequest: null` in `embed/src/redis.ts:3` would make commands queue instead of rejecting fatally; narrowing the `uncaughtException` re-throw in identity is the deeper fix but is shared with iam.
- `infra/aws/embed.ts:402` and `infra/aws/iam.ts:409` both set `name: "Redis Connection Error"`, so only one alarm exists in AWS (the iam one won) — embed has no Redis alarm.
- `infra/aws/embed.ts:391`'s filter pattern `"REDIS CONNECTION ERROR:"` never matches: `embed/src/redis.ts:11` logs `"Redis connection error:"`, and filter patterns are case-sensitive.
- The ACM DNS-validation CNAME `_e7e91299….api.scorer.gitcoin.co` and `core-alb.api.scorer.gitcoin.co` are stranded in the same orphaned zone. That cert can't re-validate on renewal.
- Longer term, `core-infra/aws/index.ts:344` has a standing TODO to move this record into the VPC-private `private.gitcoin.co` zone, which would have made this immune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rv7XSyh6VXgVPNmJ4LAqp9