### PR TITLE
fix(platforms): verify Steam OpenID assertions before issuing stamp

### DIFF
--- a/app/__tests__/pages/app.test.tsx
+++ b/app/__tests__/pages/app.test.tsx
@@ -43,3 +43,32 @@ describe("when index is provided queryParams matching twitters OAuth response", 
     expect(mockCloseWindow).toBeCalledTimes(1);
   });
 });
+
+describe("when index is provided Steam OpenID query params", () => {
+  it("should postMessage the full OpenID query string and close window", async () => {
+    mockPostMessage.mockClear();
+    const mockCloseWindow = vi.fn();
+    const search =
+      "?openid.claimed_id=https%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F76561198000000000&openid.mode=id_res&openid.sig=abc&state=steam-123";
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { search },
+    });
+    Object.defineProperty(window, "close", {
+      writable: true,
+      value: mockCloseWindow,
+    });
+
+    const appProps = {} as AppProps;
+    render(<App {...appProps} />);
+
+    expect(mockPostMessage).toBeCalledTimes(1);
+    const posted = mockPostMessage.mock.calls[0][0];
+    expect(posted.target).toBe("steam");
+    expect(posted.data.code).toContain("steamcommunity.com/openid/id/");
+    expect(posted.data.openid).toContain("openid.claimed_id=");
+    expect(posted.data.openid).toContain("openid.sig=");
+    expect(mockCloseWindow).toBeCalledTimes(1);
+  });
+});

--- a/app/context/stampClaimingContext.tsx
+++ b/app/context/stampClaimingContext.tsx
@@ -39,7 +39,7 @@ export const waitForRedirect = (platform: Platform, timeout?: number): Promise<P
 
   const waitForRedirect = new Promise<ProviderPayload>((resolve, reject) => {
     // Listener to watch for oauth redirect response on other windows (on the same host)
-    function listenForRedirect(e: { target: string; data: { code: string; state: string } }) {
+    function listenForRedirect(e: { target: string; data: { code: string; state: string; openid?: string } }) {
       // when receiving oauth response from a spawned child run fetchVerifiableCredential
       if (e.target === platform.path) {
         // pull data from message
@@ -47,7 +47,11 @@ export const waitForRedirect = (platform: Platform, timeout?: number): Promise<P
         const queryState = e.data.state;
         datadogLogs.logger.info("Saving Stamp", { platform: platform.platformId });
         try {
-          resolve({ code: queryCode, state: queryState });
+          resolve({
+            code: queryCode,
+            state: queryState,
+            ...(e.data.openid ? { openid: e.data.openid } : {}),
+          });
         } catch (e) {
           datadogLogs.logger.error("Error saving Stamp", { platform: platform.platformId });
           reject(e);

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -165,7 +165,11 @@ function App({ Component, pageProps }: AppProps) {
       if (code) {
         channel.postMessage({
           target: provider,
-          data: { code: code, state: queryState },
+          data: {
+            code: code,
+            state: queryState,
+            ...(openIdClaimedId ? { openid: queryString.toString() } : {}),
+          },
         });
       }
 

--- a/platforms/src/Steam/App-Bindings.ts
+++ b/platforms/src/Steam/App-Bindings.ts
@@ -48,12 +48,13 @@ export class SteamPlatform extends Platform {
 
     // Wait for OpenID redirect response
     return appContext.waitForRedirect(this).then((data) => {
-      // Steam OpenID returns claimed_id in the response
-      // The frontend callback handler extracts openid.claimed_id and passes it as 'code'
+      // Steam OpenID returns claimed_id plus the signed assertion query string.
+      // IAM must verify the assertion with Steam; claimed_id alone is not enough.
       return {
         code: data.code || "",
         sessionKey: data.state,
         signature: data.signature,
+        openid: typeof data.openid === "string" ? data.openid : "",
       };
     });
   }

--- a/platforms/src/Steam/Providers/steamGamingCredentials.ts
+++ b/platforms/src/Steam/Providers/steamGamingCredentials.ts
@@ -56,22 +56,33 @@ export class SteamProvider implements Provider {
     let record = undefined;
 
     try {
-      // 1. Extract Steam ID from OpenID claimed_id
-      // The frontend passes openid.claimed_id as 'code' in the OAuth flow
-      const claimedId = payload.proofs?.code as string | undefined;
-      if (!claimedId) {
+      // 1. Verify the Steam OpenID assertion with Steam, then take the Steam ID
+      // from the verified claimed_id. claimed_id alone is client-controlled.
+      const assertion = typeof payload.proofs?.openid === "string" ? payload.proofs.openid : "";
+      if (!assertion) {
         return {
           valid: false,
-          errors: ["Missing Steam OpenID claimed_id"],
+          errors: ["Missing Steam OpenID assertion"],
         };
       }
 
-      const steamId = extractSteamId(claimedId);
+      const steamId = await verifySteamOpenIdAssertion(assertion);
       if (!steamId) {
         return {
           valid: false,
-          errors: ["Invalid Steam OpenID response. Unable to extract Steam ID."],
+          errors: ["Steam OpenID assertion could not be verified."],
         };
+      }
+
+      const claimedId = payload.proofs?.code as string | undefined;
+      if (claimedId) {
+        const claimedSteamId = extractSteamId(claimedId);
+        if (claimedSteamId !== steamId) {
+          return {
+            valid: false,
+            errors: ["Steam OpenID claimed_id does not match the verified assertion."],
+          };
+        }
       }
 
       // 2. Fetch gaming data from Steam API
@@ -141,6 +152,56 @@ export class SteamProvider implements Provider {
 function extractSteamId(claimedId: string): string | null {
   const match = claimedId.match(/^https:\/\/steamcommunity\.com\/openid\/id\/(\d{17})$/);
   return match ? match[1] : null;
+}
+
+const STEAM_OPENID_ENDPOINT = "https://steamcommunity.com/openid/login";
+
+/**
+ * Ask Steam to confirm an OpenID 2.0 id_res assertion (check_authentication).
+ * Returns the 17-digit Steam ID when Steam says the assertion is valid.
+ */
+export async function verifySteamOpenIdAssertion(assertion: string): Promise<string | null> {
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(assertion);
+  } catch {
+    return null;
+  }
+
+  const claimedId = params.get("openid.claimed_id");
+  const sig = params.get("openid.sig");
+  const opEndpoint = params.get("openid.op_endpoint");
+  if (!claimedId || !sig) {
+    return null;
+  }
+  if (opEndpoint && opEndpoint !== STEAM_OPENID_ENDPOINT) {
+    return null;
+  }
+
+  const steamId = extractSteamId(claimedId);
+  if (!steamId) {
+    return null;
+  }
+
+  const verifyParams = new URLSearchParams(params);
+  verifyParams.set("openid.mode", "check_authentication");
+
+  let body: string;
+  try {
+    const response = await axios.post(STEAM_OPENID_ENDPOINT, verifyParams.toString(), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      timeout: 10_000,
+    });
+    body = typeof response.data === "string" ? response.data : String(response.data ?? "");
+  } catch {
+    return null;
+  }
+
+  if (!/(?:^|\n)is_valid\s*:\s*true(?:\s|$)/im.test(body)) {
+    return null;
+  }
+
+  return steamId;
 }
 
 // Helper: Fetch gaming data from Steam Web API

--- a/platforms/src/Steam/__tests__/steamGamingCredentials.test.ts
+++ b/platforms/src/Steam/__tests__/steamGamingCredentials.test.ts
@@ -16,6 +16,27 @@ const originalEnv = process.env;
 const MOCK_STEAM_ID = "76561198000000000";
 const MOCK_CLAIMED_ID = `https://steamcommunity.com/openid/id/${MOCK_STEAM_ID}`;
 
+function mockOpenIdAssertion(steamId: string): string {
+  return new URLSearchParams({
+    "openid.ns": "http://specs.openid.net/auth/2.0",
+    "openid.mode": "id_res",
+    "openid.op_endpoint": "https://steamcommunity.com/openid/login",
+    "openid.claimed_id": `https://steamcommunity.com/openid/id/${steamId}`,
+    "openid.identity": `https://steamcommunity.com/openid/id/${steamId}`,
+    "openid.return_to": "https://passport.human.tech/",
+    "openid.response_nonce": "2026-01-01T00:00:00Znonce",
+    "openid.assoc_handle": "1234567890",
+    "openid.signed": "signed,op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle",
+    "openid.sig": "dGVzdHNpZ25hdHVyZQ==",
+  }).toString();
+}
+
+const MOCK_OPENID = mockOpenIdAssertion(MOCK_STEAM_ID);
+const validProofs = {
+  code: MOCK_CLAIMED_ID,
+  openid: MOCK_OPENID,
+};
+
 // Mock Steam API responses
 const validGamesResponse = {
   data: {
@@ -91,6 +112,11 @@ beforeEach(() => {
     STEAM_API_KEY: "test_api_key",
   };
 
+  mockedAxios.post.mockResolvedValue({
+    data: "ns:http://specs.openid.net/auth/2.0\nis_valid:true\n",
+    status: 200,
+  });
+
   // Default mock: return valid games response
   mockedAxios.get.mockImplementation(async (url: string) => {
     if (url.includes("GetOwnedGames")) {
@@ -113,7 +139,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -129,7 +155,7 @@ describe("SteamProvider", function () {
       expect(result.errors).toBeUndefined();
     });
 
-    it("should return invalid when missing claimed_id", async () => {
+    it("should return invalid when missing OpenID assertion", async () => {
       const provider = new SteamProvider();
       const payload = {
         proofs: {},
@@ -139,14 +165,51 @@ describe("SteamProvider", function () {
 
       expect(result.valid).toBe(false);
       expect(result.record).toBeUndefined();
-      expect(result.errors).toEqual(["Missing Steam OpenID claimed_id"]);
+      expect(result.errors).toEqual(["Missing Steam OpenID assertion"]);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    it("should return invalid when Steam rejects the OpenID assertion", async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: "ns:http://specs.openid.net/auth/2.0\nis_valid:false\n",
+        status: 200,
+      });
+
+      const provider = new SteamProvider();
+      const payload = {
+        proofs: validProofs,
+      } as unknown as RequestPayload;
+
+      const result = await provider.verify(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.record).toBeUndefined();
+      expect(result.errors).toEqual(["Steam OpenID assertion could not be verified."]);
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    it("should return invalid when claimed_id does not match the verified assertion", async () => {
+      const provider = new SteamProvider();
+      const payload = {
+        proofs: {
+          code: "https://steamcommunity.com/openid/id/76561198000000001",
+          openid: MOCK_OPENID,
+        },
+      } as unknown as RequestPayload;
+
+      const result = await provider.verify(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(["Steam OpenID claimed_id does not match the verified assertion."]);
+      expect(mockedAxios.get).not.toHaveBeenCalled();
     });
 
     it("should return invalid when claimed_id format is invalid", async () => {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: "invalid-claimed-id",
+          openid: "openid.claimed_id=not-a-steam-url&openid.sig=dGVzdA==",
         },
       } as unknown as RequestPayload;
 
@@ -154,7 +217,7 @@ describe("SteamProvider", function () {
 
       expect(result.valid).toBe(false);
       expect(result.record).toBeUndefined();
-      expect(result.errors).toEqual(["Invalid Steam OpenID response. Unable to extract Steam ID."]);
+      expect(result.errors).toEqual(["Steam OpenID assertion could not be verified."]);
     });
 
     it("should return invalid when no games found (private profile)", async () => {
@@ -168,7 +231,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -208,7 +271,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -264,7 +327,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -308,7 +371,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -357,7 +420,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -376,7 +439,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -389,7 +452,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 
@@ -418,7 +481,7 @@ describe("SteamProvider", function () {
       const provider = new SteamProvider();
       const payload = {
         proofs: {
-          code: MOCK_CLAIMED_ID,
+          ...validProofs,
         },
       } as unknown as RequestPayload;
 


### PR DESCRIPTION
## What changed

The Steam stamp now sends the OpenID assertion to Steam `check_authentication` and only then reads the Steam ID from the verified `claimed_id`. The popup forwards the full OpenID query string (not just `claimed_id`) so IAM can check it.

## Why

`/verify` treated `proofs.code` as a Steam `claimed_id` and never asked Steam whether that assertion was signed. Anyone who can authenticate to IAM (JWT or challenge) could submit a public Steam profile URL and receive a Steam stamp if that profile met the playtime rules.

Threat model: the caller already controls their own Passport session. They do not control Steam login for an arbitrary 17-digit Steam ID. The missing check is what bound those two.

## Risk

**MEDIUM.** Existing Steam stamp claims will fail until the app sends `proofs.openid`. That is the same popup path this PR updates.

## Validation

- [x] Targeted tests: `yarn workspace @gitcoin/passport-platforms test --testPathPattern=steamGamingCredentials` (13 passed)
- [x] Revert-tested: dropping the `is_valid:true` check makes "Steam rejects the OpenID assertion" fail
- [ ] Full suite / broader validation: N/A locally (platforms Steam tests only; app suite needs a full workspace build)

## Architecture / behavior impact

IAM Steam verification now depends on Steam's OpenID endpoint being reachable. No schema or on-chain provider bitmap change.

## Review focus

`verifySteamOpenIdAssertion` in `platforms/src/Steam/Providers/steamGamingCredentials.ts`, and the `openid` field threaded through `_app.tsx` -> `stampClaimingContext` -> `Steam/App-Bindings`.

## Known concerns

Steam `check_authentication` is a live HTTPS call. Tests mock `axios.post`. If Steam is down, stamp issuance fails closed.


Made with [Cursor](https://cursor.com)