### PR TITLE
fix(app): replace Set.intersection() with filter for broad browser compat

### DIFF
--- a/app/components/PlatformCard.tsx
+++ b/app/components/PlatformCard.tsx
@@ -136,8 +136,7 @@ const VerifiedStamp = ({
   useEffect(() => {
     const onchainProviderSet = new Set(activeChainProviders.map((p) => p.providerName));
     const providerSet = new Set(platformProviders);
-    const intersection = onchainProviderSet.intersection(providerSet);
-    setIsAnyOnchain(intersection.size > 0);
+    setIsAnyOnchain([...onchainProviderSet].some((p) => providerSet.has(p)));
   }, [activeChainProviders, platformProviders]);
 
   const style = {


### PR DESCRIPTION
## Summary

- `PlatformCard.tsx` called `Set.prototype.intersection()`, which is only available in Chrome ≥122, Firefox ≥127, Safari ≥17 — any older browser throws an uncaught `TypeError`
- No React error boundary exists in the app, so this crash takes down the entire client-rendered dashboard
- **Fix**: replace with `[...onchainProviderSet].some(p => providerSet.has(p))` — equivalent logic, universal compatibility

## Evidence (Datadog, passport-prod, 7d)

130 error events / 6 sessions / 5 countries (JP, LT, MA, RU, CH) — every sampled browser version (Chrome 109, Iron 118, Chrome 120) is below the real support cutoffs, confirmed via MDN browser-compat-data.

Fixes holonym-foundation/internal-docs#2630

## Test plan

- [ ] Confirm `PlatformCard` still correctly marks stamps as on-chain when `activeChainProviders` overlaps with `platformProviders`
- [ ] Confirm it shows off-chain correctly when there's no overlap
- [ ] Smoke-test on an older browser (Chrome <122 or Firefox <127) if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)