### PR TITLE
fix(platforms): add 10s timeout to model-predict axios calls

### DIFF
--- a/platforms/src/ETH/Providers/accountAnalysis.ts
+++ b/platforms/src/ETH/Providers/accountAnalysis.ts
@@ -92,7 +92,7 @@ export async function fetchModelData<T>(address: string, url_subpath: string, da
       payload["data"] = data;
     }
     const url = `http://${dataScienceEndpoint}/${url_subpath}`;
-    const response = await axios.post<T>(url, payload);
+    const response = await axios.post<T>(url, payload, { timeout: 10_000 });
 
     return response.data;
   } catch (e) {

--- a/platforms/src/NFT/Providers/collectors_journey.ts
+++ b/platforms/src/NFT/Providers/collectors_journey.ts
@@ -78,9 +78,7 @@ export class NftCollectorBaseProvider extends NftBaseProvider {
     const providerUrl = `http://${dataScienceEndpoint}/nft-model-predict`;
     try {
       return (
-        await axios.post(providerUrl, {
-          address,
-        })
+        await axios.post(providerUrl, { address }, { timeout: 10_000 })
       ).data as NftApiResponse;
     } catch (error) {
       handleProviderModelAxiosError(error, "queryNftStampApi", []);


### PR DESCRIPTION
## Summary

`fetchModelData` (`accountAnalysis.ts`) and `queryNftStampApi` (`collectors_journey.ts`) were making `axios.post` calls with no timeout. When the internal ALB is slow or returns an error page, these calls hang indefinitely, blocking `Promise.all` across all 6 parallel chain model calls in `getAggregateAnalysis`.

Adds `{ timeout: 10_000 }` to both call sites. Axios timeout throws `AxiosError(ECONNABORTED)`, which `handleProviderModelAxiosError` correctly classifies as `ProviderBackendError` — same path as a 5xx.

## Relates to
holonym-foundation/internal-docs#2672 — the Python `passport-v2-model-score` ContentTypeError from the same ALB is a separate issue that needs access to the data science Lambda; this fixes the identical missing-timeout on the TypeScript side.

## Test plan
- [ ] `platforms` unit tests pass in CI
- [ ] Verify timeout error surfaces as `ProviderBackendError` (not silent) in staging