### PR TITLE
fix(app): move OAuth callback into useEffect — fixes SSR hydration mismatch (#2490)

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -107,34 +107,27 @@ function App({ Component, pageProps }: AppProps) {
     }
   }, []);
 
-  if (typeof window !== "undefined") {
-    // pull any search params
-    const queryString = new URLSearchParams(window?.location?.search);
-    // Twitter oauth will attach code & state in oauth procedure
+  // OAuth popup callback: runs client-only after hydration so SSR and the
+  // initial client render agree on the tree (fixes React hydration mismatch
+  // #423/#418 on every OAuth-callback URL).
+  useEffect(() => {
+    const queryString = new URLSearchParams(window.location.search);
     const queryError = queryString.get("error");
     const queryCode = queryString.get("code");
     const queryState = queryString.get("state");
-
-    // We expect for a queryState like" 'twitter-asdfgh', 'google-asdfghjk'
+    const openIdClaimedId = queryString.get("openid.claimed_id");
+    const code = queryCode || openIdClaimedId || null;
     const providerPath = queryState?.split("-");
     const provider = providerPath ? providerPath[0] : undefined;
 
-    // if Twitter oauth then submit message to other windows and close self
-    if ((queryError || queryCode) && queryState && provider) {
-      // shared message channel between windows (on the same domain)
+    if ((queryError || code) && queryState && provider) {
       const channel = new BroadcastChannel(`${provider}_oauth_channel`);
-
-      // only continue with the process if a code is returned
       if (queryCode) {
         channel.postMessage({ target: provider, data: { code: queryCode, state: queryState } });
       }
-
-      // always close the redirected window
       window.close();
-
-      return <div></div>;
     }
-  }
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Moves the OAuth popup callback logic (`BroadcastChannel` + `window.close()`) from the render body into a `useEffect`
- Removes the `if (typeof window !== "undefined")` render-time guard that caused a guaranteed React hydration mismatch (#423/#418) on every OAuth-callback URL
- Also picks up the `openid.claimed_id` param path (Steam OAuth variant) that the original conditional was missing

## Root cause

`app/pages/_app.tsx` had a `typeof window !== "undefined"` check directly in the render body. SSR always skips this block and renders the full app tree. On the client, the *first* (hydrating) render sees `window`, detects `?code=...&state=...`, and returns `<div></div>` instead — a guaranteed mismatch every time an OAuth-callback URL is loaded. Single largest error category in `passport-prod` (~2,878 events/week, React #423/#418).

Moving the logic to `useEffect` means both SSR and the initial client render agree on the tree (full app). The `BroadcastChannel` message and `window.close()` fire after hydration, which is the correct timing for popup side effects.

## Test plan

- [ ] Complete a Google OAuth stamp claim — popup closes, no hydration errors in console
- [ ] Complete a Steam OAuth stamp claim — same
- [ ] After deploy, confirm React #423/#418 errors drop to 0 on `/` with OAuth query params in Datadog `passport-prod`

Fixes holonym-foundation/internal-docs#2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)