### PR TITLE
fix(phone-stamp): maintenance banner during Messente → Twilio migration

### DIFF
--- a/platforms/src/HumanIdPhone/App-Bindings.ts
+++ b/platforms/src/HumanIdPhone/App-Bindings.ts
@@ -13,12 +13,15 @@ export class HumanIdPhonePlatform extends BaseHumanIDPlatform {
   constructor(options: PlatformOptions) {
     super(options);
 
+    // Temporary: phone verification is disabled while migrating from Messente
+    // to Twilio Verify. Restore the original banner once Twilio is live.
+    // See holonym-foundation/internal-docs#2990
     this.banner = {
-      heading: "To add the Human ID Phone Stamp to your Passport...",
+      heading: "Phone verification is temporarily unavailable",
       content: React.createElement(
         "div",
         {},
-        "Connect your wallet and verify your phone number privately through Human ID"
+        "We're upgrading our phone verification provider. This stamp will be back shortly — check back soon."
       ),
       cta: {
         label: "Learn more",


### PR DESCRIPTION
## Summary

Phone verification is temporarily unavailable while we migrate from Messente to Twilio Verify. This PR updates the HumanIdPhone platform banner to inform users instead of letting them start a flow that will fail.

- Updates banner heading: "Phone verification is temporarily unavailable"
- Updates banner content: "We're upgrading our phone verification provider. This stamp will be back shortly."

To revert: restore original banner text once Twilio is live.

## Test plan
- [ ] Open the Phone Verification stamp card — confirm maintenance banner shows
- [ ] Confirm other stamps unaffected

Refs holonym-foundation/internal-docs#2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)