### PR TITLE
fix(app): move OAuth callback detection to useEffect to eliminate SSR hydration mismatch

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,5 +1,5 @@
 // --- React Methods
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { BroadcastChannel } from "broadcast-channel";
 
@@ -130,6 +130,12 @@ const RenderOnlyOnClient = ({ children }: { children: React.ReactNode }) => {
 };
 
 function App({ Component, pageProps }: AppProps) {
+  // True only after mount when this window is an OAuth popup callback.
+  // Initialized to false so SSR and the initial hydrating render agree on the
+  // tree — fixing the deterministic React #423/#418 hydration mismatch that
+  // fired ~2,878 events/week on passport-prod. See internal-docs#2490.
+  const [isOAuthCallback, setIsOAuthCallback] = useState(false);
+
   useEffect(() => {
     TagManager.initialize({
       gtmId: `${GTM_ID}`,
@@ -139,9 +145,9 @@ function App({ Component, pageProps }: AppProps) {
     });
   }, []);
 
-  if (typeof window !== "undefined") {
+  useEffect(() => {
     // pull any search params
-    const queryString = new URLSearchParams(window?.location?.search);
+    const queryString = new URLSearchParams(window.location.search);
     // Twitter oauth will attach code & state in oauth procedure
     const queryError = queryString.get("error");
     const queryCode = queryString.get("code");
@@ -149,7 +155,7 @@ function App({ Component, pageProps }: AppProps) {
     // Steam OpenID uses openid.claimed_id instead of code
     const openIdClaimedId = queryString.get("openid.claimed_id");
 
-    // We expect for a queryState like" 'twitter-asdfgh', 'google-asdfghjk'
+    // We expect for a queryState like 'twitter-asdfgh', 'google-asdfghjk'
     const providerPath = queryState?.split("-");
     const provider = providerPath ? providerPath[0] : undefined;
 
@@ -169,11 +175,15 @@ function App({ Component, pageProps }: AppProps) {
         });
       }
 
+      setIsOAuthCallback(true);
+
       // always close the redirected window
       window.close();
-
-      return <div></div>;
     }
+  }, []);
+
+  if (isOAuthCallback) {
+    return <div></div>;
   }
 
   return (


### PR DESCRIPTION
## Problem

React errors #423 and #418 were firing ~2,878 events/week on passport-prod. Root cause: the OAuth popup detection used `typeof window !== "undefined"` in the render body.

- **SSR**: `window` is undefined → renders full app tree
- **Client hydrate**: `window` exists and OAuth params are present → returns `<div></div>`

These two trees don't match → React hydration mismatch.

## Fix

Move OAuth callback detection to a `useEffect` with `useState(false)`:

- `isOAuthCallback` initialises as `false` on both server and client
- SSR and the first hydrating render both produce the full app tree (they agree)
- After mount, the effect reads query params, posts the `BroadcastChannel` message, sets `isOAuthCallback = true`, and calls `window.close()`
- The state flip triggers a normal client-side re-render — no hydration involved

No behavioral change to the OAuth flow: the BroadcastChannel message reaches the parent window exactly as before.

## Test plan

- [ ] Normal app load has no hydration errors.
- [ ] Google callback reaches the parent window and completes verification.
- [ ] Steam callback forwards the OpenID response and completes verification.
- [ ] If window.close() is blocked, the callback page remains blank without a hydration mismatch.

Fixes internal-docs#2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)